### PR TITLE
Add optional start of minikube to delete script

### DIFF
--- a/deleteNetwork.sh
+++ b/deleteNetwork.sh
@@ -2,6 +2,12 @@
 
 source ./env.sh
 
+# Make sure minikube is running
+if minikube status | grep -q 'host: Stopped'; then
+  minikube start
+fi
+
+# Delete namespace and all contained resources
 kubectl delete -f $K8S/namespace.yaml
 
 echo Delete temporary directories


### PR DESCRIPTION
Reason for pull request:
 - when minikube is not running, the delete script has weird side effects since it cannot remove old resources

Changes:
 - Add optional start of minikube to delete script