### PR TITLE
Feature/setup couchdb

### DIFF
--- a/k8s-templates/org1-peer1/org1-peer1.yaml
+++ b/k8s-templates/org1-peer1/org1-peer1.yaml
@@ -56,6 +56,14 @@ spec:
               value: "peer1-org1:7052"
             - name: CORE_PEER_CHAINCODELISTENADDRESS
               value: "0.0.0.0:7052"
+            - name: CORE_LEDGER_STATE_STATEDATABASE
+              value: "CouchDB"
+            - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
+              value: "localhost:5984"
+        - name: couchdb
+          image: hyperledger/fabric-couchdb:latest
+          ports:
+            - containerPort: 5984
       volumes:
         - name: peer1-org1-mount
           hostPath:

--- a/k8s-templates/org1-peer2/org1-peer2.yaml
+++ b/k8s-templates/org1-peer2/org1-peer2.yaml
@@ -56,7 +56,14 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_BOOTSTRAP
               value: "peer1-org1:7051"
-
+            - name: CORE_LEDGER_STATE_STATEDATABASE
+              value: "CouchDB"
+            - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
+              value: "localhost:5984"
+        - name: couchdb
+          image: hyperledger/fabric-couchdb:latest
+          ports:
+            - containerPort: 5984
       volumes:
         - name: peer2-org1-mount
           hostPath:

--- a/k8s-templates/org2-peer1/org2-peer1.yaml
+++ b/k8s-templates/org2-peer1/org2-peer1.yaml
@@ -51,6 +51,14 @@ spec:
               value: "peer1-org2:7051"
             - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
               value: "true"
+            - name: CORE_LEDGER_STATE_STATEDATABASE
+              value: "CouchDB"
+            - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
+              value: "localhost:5984"
+        - name: couchdb
+          image: hyperledger/fabric-couchdb:latest
+          ports:
+            - containerPort: 5984
       volumes:
         - name: peer1-org2-mount
           hostPath:

--- a/k8s-templates/org2-peer2/org2-peer2.yaml
+++ b/k8s-templates/org2-peer2/org2-peer2.yaml
@@ -52,6 +52,14 @@ spec:
               value: "true"
             - name: CORE_PEER_GOSSIP_BOOTSTRAP
               value: "peer1-org2:7051"
+            - name: CORE_LEDGER_STATE_STATEDATABASE
+              value: "CouchDB"
+            - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
+              value: "localhost:5984"
+        - name: couchdb
+          image: hyperledger/fabric-couchdb:latest
+          ports:
+            - containerPort: 5984
       volumes:
         - name: peer2-org2-mount
           hostPath:

--- a/scripts/getLog.sh
+++ b/scripts/getLog.sh
@@ -7,8 +7,12 @@ get_pods() {
 
 if [ -z "$1" ]
 then
-  echo "Usage: ./getLogs.sh deployment-name"
+  echo "Usage: ./getLogs.sh deployment-name [containername]"
 else
-  echo "Log for $1:"
-  kubectl logs $(get_pods "$1") -n hlf-production-network
+  if [ -z "$2" ]
+  then
+    kubectl logs $(get_pods "$1") -n hlf-production-network
+  else
+    kubectl logs $(get_pods "$1") -c $2 -n hlf-production-network
+  fi
 fi

--- a/scripts/podShell.sh
+++ b/scripts/podShell.sh
@@ -5,9 +5,15 @@ get_pods() {
   kubectl get pods -l app=$1 --field-selector status.phase=Running -n hlf-production-network --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | head -n 1
 }
 
+
 if [ -z "$1" ]
 then
-  echo "Usage: ./podShell.sh deployment-name"
+  echo "Usage: ./podShell.sh deployment-name [container name]"
 else
-  kubectl exec -n hlf-production-network $(get_pods "$1")  -it -- sh
+  if [ -z "$2" ]
+  then
+    kubectl exec -n hlf-production-network $(get_pods "$1")  -it -- sh
+  else
+    kubectl exec -n hlf-production-network $(get_pods "$1")  -c $2 -it -- sh
+  fi
 fi

--- a/startNetwork.sh
+++ b/startNetwork.sh
@@ -437,6 +437,7 @@ start-org1-peer1() {
 
   kubectl create -f "$K8S/org1-peer1/org1-peer1.yaml" -n hlf-production-network
   kubectl create -f "$K8S/org1-peer1/org1-peer1-service.yaml" -n hlf-production-network
+  kubectl wait --for=condition=ready pod -l app=peer1-org1 --timeout=120s -n hlf-production-network
 }
 
 start-org1-peer2() {
@@ -446,6 +447,7 @@ start-org1-peer2() {
 
   kubectl create -f "$K8S/org1-peer2/org1-peer2.yaml" -n hlf-production-network
   kubectl create -f "$K8S/org1-peer2/org1-peer2-service.yaml" -n hlf-production-network
+  kubectl wait --for=condition=ready pod -l app=peer2-org1 --timeout=120s -n hlf-production-network
 }
 
 start-org2-peer1() {
@@ -455,6 +457,7 @@ start-org2-peer1() {
 
   kubectl create -f "$K8S/org2-peer1/org2-peer1.yaml" -n hlf-production-network
   kubectl create -f "$K8S/org2-peer1/org2-peer1-service.yaml" -n hlf-production-network
+  kubectl wait --for=condition=ready pod -l app=peer1-org2 --timeout=120s -n hlf-production-network
 }
 
 start-org2-peer2() {
@@ -464,6 +467,8 @@ start-org2-peer2() {
 
   kubectl create -f "$K8S/org2-peer2/org2-peer2.yaml" -n hlf-production-network
   kubectl create -f "$K8S/org2-peer2/org2-peer2-service.yaml" -n hlf-production-network
+  kubectl wait --for=condition=ready pod -l app=peer2-org2 --timeout=120s -n hlf-production-network
+
 }
 
 setup-orderer() {


### PR DESCRIPTION
Reason for this PR:
 - Add CouchDB container to each Peer's Pod.
 - We need CouchDBs for certain queries which levelDB does not support.

Changes in this PR:
 - Add couchdb to config file of each peer.
 - Adapt start script to wait until peer pods are ready.
 - Adapt debugging scripts to work with Pods that have more than one containers.