### PR TITLE
Change chaincode repository url.

### DIFF
--- a/installChaincode.sh
+++ b/installChaincode.sh
@@ -23,7 +23,7 @@ source ./env.sh
 
 echo "Download chaincode"
 mkdir -p $TMP_FOLDER/hyperledger/uc4
-wget -c https://github.com/upb-uc4/hyperledger_chaincode/archive/"$BRANCH_TAG".tar.gz -O - | tar -xz -C $TMP_FOLDER/hyperledger/uc4 --strip-components=1
+wget -c https://github.com/upb-uc4/hlf-chaincode/archive/"$BRANCH_TAG".tar.gz -O - | tar -xz -C $TMP_FOLDER/hyperledger/uc4 --strip-components=1
 
 echo "Build chaincode using gradle"
 pushd $TMP_FOLDER/hyperledger/uc4/chaincode


### PR DESCRIPTION
### Reason for this PR:

- The url of our chaincode repository has changed and we use this our `installChaincode` script.

### Change is this PR:

- Change the url in `installChaincode.sh`.