### PR TITLE
Feature/connection profile configmap

### DIFF
--- a/assets/connection_profile_kubernetes.yaml
+++ b/assets/connection_profile_kubernetes.yaml
@@ -140,7 +140,7 @@ orderers:
 
     tlsCACerts:
       # Certificate location absolute path
-      path: "/var/lib/hyperledger/data/api/ca-cert.pem"
+      path: "/var/secrets/cert.pem"
 
 #
 # List of peers to send various requests to, including endorsement, query
@@ -162,7 +162,7 @@ peers:
 
     tlsCACerts:
       # Certificate location absolute path
-      path: "/var/lib/hyperledger/data/api/ca-cert.pem"
+      path: "/var/secrets/cert.pem"
 
   peer2-org1:
     # this URL is used to send endorsement and query requests
@@ -180,7 +180,7 @@ peers:
 
     tlsCACerts:
       # Certificate location absolute path
-      path: "/var/lib/hyperledger/data/api/ca-cert.pem"
+      path: "/var/secrets/cert.pem"
 
   peer1-org2:
     # this URL is used to send endorsement and query requests
@@ -195,7 +195,7 @@ peers:
 
     tlsCACerts:
       # Certificate location absolute path
-      path: "/var/lib/hyperledger/data/api/ca-cert.pem"
+      path: "/var/secrets/cert.pem"
 
   peer2-org2:
     # this URL is used to send endorsement and query requests
@@ -210,5 +210,5 @@ peers:
 
     tlsCACerts:
       # Certificate location absolute path
-      path: "/var/lib/hyperledger/data/api/ca-cert.pem"
+      path: "/var/secrets/cert.pem"
 

--- a/scripts/startNetwork/generateSecrets.sh
+++ b/scripts/startNetwork/generateSecrets.sh
@@ -5,6 +5,11 @@ source ./scripts/env.sh
 
 header "Generate credentials and store in secrets"
 
+# Ensure lagom namespace exists
+set +e
+kubectl create namespace uc4-lagom
+set -e
+
 # For use in api: prepare folders
 # Use in lagom:
 mkdir -p $HL_MOUNT/api/org0/msp/cacerts/
@@ -13,7 +18,7 @@ mkdir -p $HL_MOUNT/api/org2/msp/cacerts/
 # Copy connection_profile_kuberntes.yaml for legacy
 cp assets/connection_profile_kubernetes.yaml $HL_MOUNT/api
 # Provide connection profile via secret for Lagom
-kubectl create configmap connection-profile --from-file=assets/connection_profile_kubernetes.yaml -n hlf
+kubectl create configmap connection-profile --from-file=assets/connection_profile_kubernetes.yaml -n uc4-lagom
 
 # Use for testing without lagom
 rm -rf /tmp/hyperledger/
@@ -37,6 +42,7 @@ small_sep
 echo "Provide certificate and privkey as kubernetes secret"
 kubectl create secret generic key.tls-ca -n hlf --from-file=key.pem=$TMP_CERT-key.pem
 kubectl create secret generic cert.tls-ca -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
+kubectl create secret generic cert.tls-ca -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
 cp $TMP_CERT-cert.pem /tmp/hyperledger/ca-cert.pem
 cp $TMP_CERT-cert.pem $HL_MOUNT/api/ca-cert.pem
@@ -56,6 +62,7 @@ small_sep
 echo "Provide certificate and privkey as kubernetes secret"
 kubectl create secret generic key.rca-org0 -n hlf --from-file=key.pem=$TMP_CERT-key.pem
 kubectl create secret generic cert.rca-org0 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
+kubectl create secret generic cert.rca-org0 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
 cp $TMP_CERT-cert.pem /tmp/hyperledger/org0/msp/cacerts/org0-ca-cert.pem
 cp $TMP_CERT-cert.pem $HL_MOUNT/api/org0/msp/cacerts/org0-ca-cert.pem
@@ -75,6 +82,7 @@ small_sep
 echo "Provide certificate and privkey as kubernetes secret"
 kubectl create secret generic key.rca-org1 -n hlf --from-file=key.pem=$TMP_CERT-key.pem
 kubectl create secret generic cert.rca-org1 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
+kubectl create secret generic cert.rca-org1 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
 cp $TMP_CERT-cert.pem /tmp/hyperledger/org1/msp/cacerts/org1-ca-cert.pem
 cp $TMP_CERT-cert.pem $HL_MOUNT/api/org1/msp/cacerts/org1-ca-cert.pem
@@ -95,6 +103,7 @@ small_sep
 echo "Provide certificate and privkey as kubernetes secret"
 kubectl create secret generic key.rca-org2 -n hlf --from-file=key.pem=$TMP_CERT-key.pem
 kubectl create secret generic cert.rca-org2 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
+kubectl create secret generic cert.rca-org2 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
 cp $TMP_CERT-cert.pem /tmp/hyperledger/org2/msp/cacerts/org2-ca-cert.pem
 cp $TMP_CERT-cert.pem $HL_MOUNT/api/org2/msp/cacerts/org2-ca-cert.pem

--- a/scripts/startNetwork/generateSecrets.sh
+++ b/scripts/startNetwork/generateSecrets.sh
@@ -10,8 +10,10 @@ header "Generate credentials and store in secrets"
 mkdir -p $HL_MOUNT/api/org0/msp/cacerts/
 mkdir -p $HL_MOUNT/api/org1/msp/cacerts/
 mkdir -p $HL_MOUNT/api/org2/msp/cacerts/
-# Copy connection_profile_kuberntes.yaml
+# Copy connection_profile_kuberntes.yaml for legacy
 cp assets/connection_profile_kubernetes.yaml $HL_MOUNT/api
+# Provide connection profile via secret for Lagom
+kubectl create configmap connection-profile --from-file=assets/connection_profile_kubernetes.yaml -n hlf
 
 # Use for testing without lagom
 rm -rf /tmp/hyperledger/


### PR DESCRIPTION
### Reason for this PR:
 - The connection profile was provided via mount which is not good practice

## Changes in this PR:
 - Provide connection profile via a config map
 - Change paths in connection_profile_kubernetes
 - Provide root certificates and connection profile to `hlf-lagom` namespace 