### PR TITLE
Feature/api test flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,23 +5,25 @@
 
 BRANCH_TAG="develop"
 CLUSTER_MOUNT="/data/development/hyperledger"
-VERBOSE=""
+TEST_MODE=""
 
 print_usage() {
   printf "Usage: ./deploy -v -b [branch or tag] -c [custom config file]\n"
-  printf "Use -v for verbose output and -b to specify a branch or tag (default develop)\n"
+  printf "Use -b to specify a branch or tag (default develop)\n"
+  printf "Use -t to activate test mode (do not use in production)\n"
   printf "Use -c to specify a cluster mount path (default %s)\n" "$CLUSTER_MOUNT"
 }
 
 
-while getopts 'vb:c:' flag; do
+while getopts 'vtb:c:' flag; do
   case "${flag}" in
     b) BRANCH_TAG="${OPTARG}"
        printf 'Using branch or tag "%s"\n' "$BRANCH_TAG" ;;
-    v) VERBOSE="-d"
-       printf 'Using verbose mode\n' ;;
     c) CLUSTER_MOUNT="${OPTARG}"
        printf 'Using hyperledger mount path "%s"\n' "$CLUSTER_MOUNT";;
+    t) TEST_MODE="-t"
+       printf 'Using test mode'
+       printf 'Do not use this mode in production!' ;;
     ?) print_usage
        exit 1 ;;
   esac
@@ -36,7 +38,7 @@ printf 'export HL_MOUNT="%s"' "$CLUSTER_MOUNT" >> scripts/env.sh   # Add CLUSTER
 
 # Start network and deploy chaincode
 
-./scripts/startNetwork.sh $VERBOSE
+./scripts/startNetwork.sh $TEST_MODE
 
 if test -z "$BRANCH_TAG"
 then

--- a/k8s/org1/peer1-org1.yaml
+++ b/k8s/org1/peer1-org1.yaml
@@ -61,18 +61,12 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
-          ports:
-            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
-          ports:
-            - containerPort: 5984
         - name: dind
           image: "docker:18.05.0-dind"
           securityContext:
             privileged: true
-          ports:
-            - containerPort: 2375
       initContainers:
         - name: fabric-ca
           image: hyperledger/fabric-ca:1.4.7

--- a/k8s/org1/peer1-org1.yaml
+++ b/k8s/org1/peer1-org1.yaml
@@ -61,6 +61,7 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
+            
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
         - name: dind
@@ -147,4 +148,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30111
-
+    - name: chaincode
+      protocol: TCP
+      port: 7052

--- a/k8s/org1/peer1-org1.yaml
+++ b/k8s/org1/peer1-org1.yaml
@@ -61,6 +61,8 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
+          ports:
+            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
           ports:

--- a/k8s/org1/peer2-org1.yaml
+++ b/k8s/org1/peer2-org1.yaml
@@ -27,10 +27,6 @@ spec:
               value: "0.0.0.0:7051"
             - name: CORE_PEER_ADDRESS
               value: "peer2-org1:7051"
-            - name: CORE_PEER_CHAINCODELISTENADDRESS
-              value: "0.0.0.0:7052"
-            - name: CORE_PEER_CHAINCODEADDRESS
-              value: "peer2-org1:7052"
             - name: CORE_PEER_LOCALMSPID
               value: "org1MSP"
             - name: CORE_PEER_MSPCONFIGPATH
@@ -53,26 +49,24 @@ spec:
               value: "false"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
               value: "peer2-org1:7051"
+            - name: CORE_PEER_BOOTSTRAP
+              value: "peer2-org1:7051"
             - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
               value: "true"
-            - name: CORE_PEER_GOSSIP_BOOTSTRAP
-              value: "peer1-org1:7051"
+            - name: CORE_PEER_CHAINCODEADDRESS
+              value: "peer2-org1:7052"
+            - name: CORE_PEER_CHAINCODELISTENADDRESS
+              value: "0.0.0.0:7052"
             - name: CORE_LEDGER_STATE_STATEDATABASE
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
-          ports:
-            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
-          ports:
-            - containerPort: 5984
         - name: dind
           image: "docker:18.05.0-dind"
           securityContext:
             privileged: true
-          ports:
-            - containerPort: 2375
       initContainers:
         - name: fabric-ca
           image: hyperledger/fabric-ca:1.4.7
@@ -120,6 +114,7 @@ spec:
                 secretKeyRef:
                   name: credentials.peer2-org1
                   key: password
+
       volumes:
         - name: peer2-org1-mount
           emptyDir: {}

--- a/k8s/org1/peer2-org1.yaml
+++ b/k8s/org1/peer2-org1.yaml
@@ -54,7 +54,7 @@ spec:
             - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
               value: "true"
             - name: CORE_PEER_CHAINCODEADDRESS
-              value: "peer2-org1:7052"
+              value: "peer1-org1:7052"
             - name: CORE_PEER_CHAINCODELISTENADDRESS
               value: "0.0.0.0:7052"
             - name: CORE_LEDGER_STATE_STATEDATABASE
@@ -147,4 +147,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30121
-
+    - name: chaincode                                                           
+      protocol: TCP                                                             
+      port: 7052    

--- a/k8s/org1/peer2-org1.yaml
+++ b/k8s/org1/peer2-org1.yaml
@@ -61,6 +61,8 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
+          ports:
+            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
           ports:

--- a/k8s/org2/peer1-org2.yaml
+++ b/k8s/org2/peer1-org2.yaml
@@ -142,4 +142,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30211
-
+    - name: chaincode                                                            
+      protocol: TCP                                                                 
+      port: 7052

--- a/k8s/org2/peer1-org2.yaml
+++ b/k8s/org2/peer1-org2.yaml
@@ -51,6 +51,8 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
+          ports:
+            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
           ports:

--- a/k8s/org2/peer2-org2.yaml
+++ b/k8s/org2/peer2-org2.yaml
@@ -144,4 +144,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30221
-
+    - name: chaincode                                                            
+      protocol: TCP                                                                 
+      port: 7052

--- a/k8s/org2/peer2-org2.yaml
+++ b/k8s/org2/peer2-org2.yaml
@@ -53,6 +53,8 @@ spec:
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
               value: "localhost:5984"
+          ports:
+            - containerPort: 7052
         - name: couchdb
           image: hyperledger/fabric-couchdb:latest
           ports:

--- a/restart.sh
+++ b/restart.sh
@@ -9,18 +9,21 @@ print_usage() {
   printf "🧙 Usage: ./restart [-d] [-v] [-b <branch or tag>]\n"
   printf "Use -v for verbose output\n"
   printf "Use -b to specify a chaincode branch or tag (default develop)\n"
+  printf "Use -t for test mode\n"
   printf "Use -d to reset all clusters\n"
 }
 
 PARAMS=""
 
-while getopts 'vdb:' flag; do
+while getopts 'vtdb:' flag; do
   case "${flag}" in
     b) BRANCH_TAG="${OPTARG}"
        PARAMS="$PARAMS -b $BRANCH_TAG"
        printf 'Using chaincode branch or tag "%s"\n' "$BRANCH_TAG" ;;
     v) PARAMS="$PARAMS -v"
        printf 'Using verbose mode\n' ;;
+    t) PARAMS="$PARAMS -t"
+       printf 'Using test mode\n' ;;
     d) printf "🐼 Delete all clusters and files\n"
        set +e
        kind delete clusters cluster-1 cluster-2

--- a/scripts/startNetwork.sh
+++ b/scripts/startNetwork.sh
@@ -3,12 +3,13 @@
 # Exit on errors
 set -e
 
-# Debug commands using -d flag
-export DEBUG=""
-if [[ $1 == "-d" ]]; then
-  echo "Debug mode activated"
-  export DEBUG="-d"
-fi
+TEST_MODE=""
+while getopts 't' flag; do
+  case "${flag}" in
+    t) TEST_MODE="-t" ;;
+    ?) printf 'Invalid flag!' ;;
+  esac
+done
 
 # Set environment variables
 source ./scripts/env.sh
@@ -24,10 +25,13 @@ source ./scripts/startNetwork/fixPrepareHostPath.sh
 small_sep
 kubectl create -f k8s/namespace.yaml
 
-faketime -m -f -1d /bin/bash -c scripts/startNetwork/generateSecrets.sh
+faketime -m -f -1d /bin/bash -c "scripts/startNetwork/generateSecrets.sh $TEST_MODE"
 source ./scripts/startNetwork/setupTlsCa.sh
 source ./scripts/startNetwork/setupOrdererOrgCa.sh
 source ./scripts/startNetwork/setupOrg1Ca.sh
+if [[ $TEST_MODE == "-t" ]]; then
+  source ./scripts/startNetwork/registerOrg1TestAdmin.sh
+fi
 source ./scripts/startNetwork/setupOrg2Ca.sh
 source ./scripts/startNetwork/startClis.sh
 source ./scripts/startNetwork/setupPeers.sh

--- a/scripts/startNetwork/generateSecrets.sh
+++ b/scripts/startNetwork/generateSecrets.sh
@@ -23,7 +23,7 @@ set +e
 kubectl create namespace uc4-lagom
 set -e
 
-if [[ TEST_MODE == "-t" ]]; then
+if [[ $TEST_MODE == "-t" ]]; then
   # Use for testing without lagom
   rm -rf /tmp/hyperledger/
   mkdir -p /tmp/hyperledger/
@@ -50,7 +50,7 @@ kubectl create secret generic key.tls-ca -n hlf --from-file=key.pem=$TMP_CERT-ke
 kubectl create secret generic cert.tls-ca -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
 kubectl create secret generic cert.tls-ca -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
-if [[ TEST_MODE == "-t" ]]; then
+if [[ $TEST_MODE == "-t" ]]; then
   cp $TMP_CERT-cert.pem /tmp/hyperledger/ca-cert.pem
 fi
 
@@ -78,7 +78,7 @@ kubectl create secret generic key.rca-org0 -n hlf --from-file=key.pem=$TMP_CERT-
 kubectl create secret generic cert.rca-org0 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
 kubectl create secret generic cert.rca-org0 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
-if [[ TEST_MODE == "-t" ]]; then
+if [[ $TEST_MODE == "-t" ]]; then
   cp $TMP_CERT-cert.pem /tmp/hyperledger/org0/msp/cacerts/org0-ca-cert.pem
 fi
 
@@ -121,7 +121,7 @@ kubectl create secret generic key.rca-org1 -n hlf --from-file=key.pem=$TMP_CERT-
 kubectl create secret generic cert.rca-org1 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
 kubectl create secret generic cert.rca-org1 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
-if [[ TEST_MODE == "-t" ]]; then
+if [[ $TEST_MODE == "-t" ]]; then
   cp $TMP_CERT-cert.pem /tmp/hyperledger/org1/msp/cacerts/org1-ca-cert.pem
 fi
 
@@ -191,7 +191,7 @@ kubectl create secret generic key.rca-org2 -n hlf --from-file=key.pem=$TMP_CERT-
 kubectl create secret generic cert.rca-org2 -n hlf --from-file=cert.pem=$TMP_CERT-cert.pem
 kubectl create secret generic cert.rca-org2 -n uc4-lagom --from-file=cert.pem=$TMP_CERT-cert.pem
 
-if [[ TEST_MODE == "-t" ]]; then
+if [[ $TEST_MODE == "-t" ]]; then
   cp $TMP_CERT-cert.pem /tmp/hyperledger/org2/msp/cacerts/org2-ca-cert.pem
 fi
 

--- a/scripts/startNetwork/registerOrg1TestAdmin.sh
+++ b/scripts/startNetwork/registerOrg1TestAdmin.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source ./scripts/util.sh
+source ./scripts/env.sh
+
+header "Registering test admin"
+
+kubectl exec -n hlf $(get_pods "rca-org1") -i -- bash /tmp/hyperledger/scripts/startNetwork/registerUsers/registerTestAdmin.sh

--- a/scripts/startNetwork/registerUsers/registerTestAdmin.sh
+++ b/scripts/startNetwork/registerUsers/registerTestAdmin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source "/tmp/hyperledger/scripts/util.sh"
+
+set -e
+
+export CA_ORG1_HOST=0.0.0.0:7052
+export FABRIC_CA_CLIENT_TLS_CERTFILES=/tmp/secrets/cert.pem
+export FABRIC_CA_CLIENT_HOME=/tmp/hyperledger/ca-client/
+
+log "Use CA-client to register test identities"
+
+fabric-ca-client register \
+  --id.name "test-admin" \
+  --id.secret "test-admin-pw" \
+  --id.type admin \
+  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert" \
+  -u https://$CA_ORG1_HOST
+
+log "Finished registering test admin"


### PR DESCRIPTION
### Reason for this PR:
 - The scala API needs an admin user to execute tests.
 - Release v0.11.0 causes the problem that chaincode containers cannot access the peer.

### Changes in this PR:
 - Add `-t` flag to scripts that provides files to scala API and registers an admin with a fixed password for testing.
 - Fix bug in release v0.11.0.