### PR TITLE
Feature/hyperledger version secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v.0.16.0](https://github.com/upb-uc4/hlf-network/compare/v0.13.0...v0.16.0) (Draft)
+
+## Feature
+
+- Add secret containing the version of the hlf-network to uc4-lagom namespace [#110](https://github.com/upb-uc4/hlf-network/pull/110)
+
 # [v.0.13.0](https://github.com/upb-uc4/hlf-network/compare/v0.12.0...v0.13.0) (2020-11-30) 
 
 ## Documentation

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,4 +1,4 @@
 export CONTAINER_TIMEOUT="300s"
 export SERVER_STARTUP_TIME="10"
-export HL_PRODUCTION_NETWORK_VERSION="v0.13.0"
+export HL_PRODUCTION_NETWORK_VERSION="v0.16.0"
 export HL_MOUNT="/data/development-2/hyperledger"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,3 +1,4 @@
 export CONTAINER_TIMEOUT="300s"
 export SERVER_STARTUP_TIME="10"
+export HL_PRODUCTION_NETWORK_VERSION="v0.13.0"
 export HL_MOUNT="/data/development-2/hyperledger"

--- a/scripts/startNetwork.sh
+++ b/scripts/startNetwork.sh
@@ -45,5 +45,8 @@ source ./scripts/startNetwork/setupOrderer.sh
 sleep 10
 source ./scripts/startNetwork/setupChannel.sh
 
+# Create secret containing the production network version
+kubectl create secret generic uc4-production-network-version -n uc4-lagom --from-literal=version="$HL_PRODUCTION_NETWORK_VERSION"
+
 sep
 msg "Done!"


### PR DESCRIPTION
## Reason for this PR:
  - We display the version of all components in the uc4 frontend.
  - There is no endpoint for the hlf-network version.

## Changes in this PR:
 - Add environment variable for version to `env.sh`.
 - Write version to secret for uc4-lagom namespace .