### PR TITLE
Feature/sysadmin attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## [v.0.17.0](https://github.com/upb-uc4/hlf-network/compare/v0.16.0...v0.17.0) (Draft)
+
+## Feature
+
+ - Add `sysadmin=true:ecert` attribute to org1-admin, org2-admin and scala users. If added to an enrollment request, this attribute is written to the certificate of a user [#114](https://github.com/upb-uc4/hlf-network/pull/114)
+
 ## [v.0.16.0](https://github.com/upb-uc4/hlf-network/compare/v0.13.0...v0.16.0) (2021-01-21)
 
 ## Feature
 
-- Add secret containing the version of the hlf-network to uc4-lagom namespace [#110](https://github.com/upb-uc4/hlf-network/pull/110)
-- Reduce batch timeout to improve response times [#112](https://github.com/upb-uc4/hlf-network/pull/112)
+ - Add secret containing the version of the hlf-network to uc4-lagom namespace [#110](https://github.com/upb-uc4/hlf-network/pull/110)
+ - Reduce batch timeout to improve response times [#112](https://github.com/upb-uc4/hlf-network/pull/112)
 
 # [v.0.13.0](https://github.com/upb-uc4/hlf-network/compare/v0.12.0...v0.13.0) (2020-11-30) 
 

--- a/scripts/startNetwork/enrollJobs/enrollAdmin.sh
+++ b/scripts/startNetwork/enrollJobs/enrollAdmin.sh
@@ -11,7 +11,7 @@ export FABRIC_CA_CLIENT_HOME=/tmp/hyperledger/org${ORG_NUM}/admin
 export FABRIC_CA_CLIENT_TLS_CERTFILES=/tmp/secrets/rca-org${ORG_NUM}/cert.pem
 export FABRIC_CA_CLIENT_MSPDIR=msp
 
-fabric-ca-client enroll -u https://$ADMIN_IDENTITY_USER:$ADMIN_IDENTITY_PASSWORD@$CA_ORG_HOST
+fabric-ca-client enroll -u https://$ADMIN_IDENTITY_USER:$ADMIN_IDENTITY_PASSWORD@$CA_ORG_HOST --enrollment.attrs "sysAdmin"
 
 # Share admin certificate with other Pods
 mkdir -p /tmp/hyperledger/shared/org${ORG_NUM}/msp/admincerts

--- a/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
@@ -29,18 +29,20 @@ fabric-ca-client register \
 fabric-ca-client register \
   --id.name $ADMIN_ORG1_IDENTITY_USER \
   --id.secret $ADMIN_ORG1_IDENTITY_PASSWORD \
-  --id.type user \
+  --id.type admin \
+  --id.attrs "sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST
 fabric-ca-client register \
   --id.name $SCALA_ADMIN_ORG1_IDENTITY_USER \
   --id.secret $SCALA_ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
+  --id.attrs "sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST
 fabric-ca-client register \
   --id.name $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_USER \
   --id.secret $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert" \
+  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST 
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
@@ -30,7 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG2_IDENTITY_USER \
   --id.secret $ADMIN_ORG2_IDENTITY_PASSWORD \
   --id.type user \
-  --id.attrs "admin=true:ecert" \
+  --id.attrs "sysAdmin=true:ecert" \
   -u https://$CA_ORG2_HOST
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
@@ -30,6 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG2_IDENTITY_USER \
   --id.secret $ADMIN_ORG2_IDENTITY_PASSWORD \
   --id.type user \
+  --id.attrs "admin=true:ecert" \
   -u https://$CA_ORG2_HOST
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerTestAdmin.sh
+++ b/scripts/startNetwork/registerUsers/registerTestAdmin.sh
@@ -14,7 +14,7 @@ fabric-ca-client register \
   --id.name "test-admin" \
   --id.secret "test-admin-pw" \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert" \
+  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST
 
 log "Finished registering test admin"


### PR DESCRIPTION
## Reason for this PR:
 - See https://github.com/upb-uc4/hlf-chaincode/pull/129#issuecomment-763645532
 - Some chaincode should only be executed by system administrators. We need some authenticated way of identifying sysadmins in the chaincode.

## Changes in this PR:
 - Add attribute sysAdmin=true to the ecert / registration of org1-admin, org2-admin (both used in CLI containers), and scala-admin / scala-registration-admin.
 - Enroll org1-admin and org2-admin with the sysAdmin attribute.