### PR TITLE
Remove matrix from workflow since random behaviour not present anymore.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,10 +23,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Test network on kind
-    strategy:
-        fail-fast: false
-        matrix:
-            we_just_want_to_repeat: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Feature
 
  - Add `sysadmin=true:ecert` attribute to org1-admin, org2-admin and scala users. If added to an enrollment request, this attribute is written to the certificate of a user [#114](https://github.com/upb-uc4/hlf-network/pull/114)
+ - Remove matrix pipeline from workflow since non-deterministic pipeline behavior was eliminated [#116](https://github.com/upb-uc4/hlf-network/pull/116)
 
 ## [v.0.16.0](https://github.com/upb-uc4/hlf-network/compare/v0.13.0...v0.16.0) (2021-01-21)
 


### PR DESCRIPTION
## Reason for this PR;
 - We had randomly failing pipelines and hence introduced a matrix setup to avoid false positives.
 - This was not a problem anymore for months, so we do not need the computational overhead.

## Changes in this PR:
 - Change from matrix setup to single run of workflow.