### PR TITLE
Add ability to set arbitrary attributes to the matching admins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Feature
 
+ - Allow admins to add arbitrary attributes when registering users by using the `hl.Registrar.Attributes` attribute [#118](https://github.com/upb-uc4/hlf-network/pull/118)
  - Add `sysadmin=true:ecert` attribute to org1-admin, org2-admin and scala users. If added to an enrollment request, this attribute is written to the certificate of a user [#114](https://github.com/upb-uc4/hlf-network/pull/114)
  - Remove matrix pipeline from workflow since non-deterministic pipeline behavior was eliminated [#116](https://github.com/upb-uc4/hlf-network/pull/116)
  - Add persistence to all pods [#109](https://github.com/upb-uc4/hlf-network/pull/109)

--- a/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
@@ -25,7 +25,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG0_IDENTITY_USER \
   --id.secret $ADMIN_ORG0_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert' \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes=*:ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert' \
   -u https://$CA_ORDERER_HOST
 
 log "Finished registering Orderer Org users"

--- a/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
@@ -25,7 +25,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG0_IDENTITY_USER \
   --id.secret $ADMIN_ORG0_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert" \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert' \
   -u https://$CA_ORDERER_HOST
 
 log "Finished registering Orderer Org users"

--- a/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrdererOrgUsers.sh
@@ -25,7 +25,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG0_IDENTITY_USER \
   --id.secret $ADMIN_ORG0_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,abac.init=true:ecert" \
+  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes=*,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert" \
   -u https://$CA_ORDERER_HOST
 
 log "Finished registering Orderer Org users"

--- a/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
@@ -42,7 +42,7 @@ fabric-ca-client register \
   --id.name $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_USER \
   --id.secret $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
+  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes='*',hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST 
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
@@ -30,7 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG1_IDENTITY_USER \
   --id.secret $ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "sysAdmin=true:ecert" \
+  --id.attrs 'hf.Registrar.Attributes="*":ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST
 fabric-ca-client register \
   --id.name $SCALA_ADMIN_ORG1_IDENTITY_USER \
@@ -42,7 +42,7 @@ fabric-ca-client register \
   --id.name $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_USER \
   --id.secret $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes='*',hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecer,admin=true:ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST 
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg1CaUsers.sh
@@ -30,7 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG1_IDENTITY_USER \
   --id.secret $ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs 'hf.Registrar.Attributes="*":ecert,sysAdmin=true:ecert' \
+  --id.attrs 'hf.Registrar.Attributes=*:ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST
 fabric-ca-client register \
   --id.name $SCALA_ADMIN_ORG1_IDENTITY_USER \
@@ -42,7 +42,7 @@ fabric-ca-client register \
   --id.name $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_USER \
   --id.secret $SCALA_REGISTRATION_ADMIN_ORG1_IDENTITY_PASSWORD \
   --id.type admin \
-  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecer,admin=true:ecert,sysAdmin=true:ecert' \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes=*:ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecer,admin=true:ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST 
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
@@ -30,7 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG2_IDENTITY_USER \
   --id.secret $ADMIN_ORG2_IDENTITY_PASSWORD \
   --id.type user \
-  --id.attrs 'hf.Registrar.Attributes="*":ecert,sysAdmin=true:ecert' \
+  --id.attrs 'hf.Registrar.Attributes=*:ecert,sysAdmin=true:ecert' \
 
   -u https://$CA_ORG2_HOST
 

--- a/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
@@ -30,7 +30,7 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG2_IDENTITY_USER \
   --id.secret $ADMIN_ORG2_IDENTITY_PASSWORD \
   --id.type user \
-  --id.attrs "sysAdmin=true:ecert" \
+  --id.attrs "hf.Registrar.Attributes='*',sysAdmin=true:ecert" \
   -u https://$CA_ORG2_HOST
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
+++ b/scripts/startNetwork/registerUsers/registerOrg2CaUsers.sh
@@ -30,7 +30,8 @@ fabric-ca-client register \
   --id.name $ADMIN_ORG2_IDENTITY_USER \
   --id.secret $ADMIN_ORG2_IDENTITY_PASSWORD \
   --id.type user \
-  --id.attrs "hf.Registrar.Attributes='*',sysAdmin=true:ecert" \
+  --id.attrs 'hf.Registrar.Attributes="*":ecert,sysAdmin=true:ecert' \
+
   -u https://$CA_ORG2_HOST
 
 log "Finished registering users"

--- a/scripts/startNetwork/registerUsers/registerTestAdmin.sh
+++ b/scripts/startNetwork/registerUsers/registerTestAdmin.sh
@@ -16,7 +16,7 @@ fabric-ca-client register \
   --id.name "test-admin" \
   --id.secret "test-admin-pw" \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes='*',hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST
 
 log "Finished registering test admin"

--- a/scripts/startNetwork/registerUsers/registerTestAdmin.sh
+++ b/scripts/startNetwork/registerUsers/registerTestAdmin.sh
@@ -16,7 +16,7 @@ fabric-ca-client register \
   --id.name "test-admin" \
   --id.secret "test-admin-pw" \
   --id.type admin \
-  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes="*":ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert,sysAdmin=true:ecert' \
+  --id.attrs 'hf.Registrar.Roles=client:ecert,hf.Registrar.Attributes=*:ecert,hf.Revoker=true:ecert,hf.GenCRL=true:ecert,admin=true:ecert,sysAdmin=true:ecert' \
   -u https://$CA_ORG1_HOST
 
 log "Finished registering test admin"

--- a/scripts/startNetwork/registerUsers/registerTestAdmin.sh
+++ b/scripts/startNetwork/registerUsers/registerTestAdmin.sh
@@ -10,11 +10,13 @@ export FABRIC_CA_CLIENT_HOME=/tmp/hyperledger/ca-client/
 
 log "Use CA-client to register test identities"
 
+# hf.Registrar.Attributes=* to allow tests setting arbitrary attributes
+
 fabric-ca-client register \
   --id.name "test-admin" \
   --id.secret "test-admin-pw" \
   --id.type admin \
-  --id.attrs "hf.Registrar.Roles=client,hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
+  --id.attrs "hf.Registrar.Roles=client,hf.Registrar.Attributes='*',hf.Revoker=true,hf.GenCRL=true,admin=true:ecert,sysAdmin=true:ecert" \
   -u https://$CA_ORG1_HOST
 
 log "Finished registering test admin"


### PR DESCRIPTION
## Reason for this PR:
 - We want our admins to add custom attributes to users' registrations

## Changes in this PR:
 - Add `hf.Registrar.Attributes='*'` to allow admins setting arbitrary custom attributes (see [CA docu](https://hyperledger-fabric-ca.readthedocs.io/en/release-1.4/users-guide.html#registering-a-new-identity))