### PR TITLE
Refactor config files for org2 and fix wrong volume claimed bug cause…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Next Release](https://github.com/upb-uc4/hlf-network/compare/v0.17.0...v0.18.0) (2021-02-XX)
+
+## Bugfix
+
+ - Fix bug in configuration of peer2-org2 [#120](https://github.com/upb-uc4/hlf-network/pull/120)
+
 ## [v.0.17.0](https://github.com/upb-uc4/hlf-network/compare/v0.16.0...v0.17.0) (2021-02-01)
 
 ## Feature

--- a/k8s/org2/cli-org2.yaml
+++ b/k8s/org2/cli-org2.yaml
@@ -15,7 +15,7 @@ spec:
         app: cli-org2
     spec:
       containers:
-        - name: cli-org1
+        - name: cli-org2
           image: hyperledger/fabric-tools:2.2
           imagePullPolicy: IfNotPresent
           tty: true
@@ -82,21 +82,22 @@ spec:
                 secretKeyRef:
                   name: credentials.admin-org2
                   key: password
+
       volumes:
         - name: shared-volume
           hostPath:
             path: /mnt/hyperledger/shared
-        - name: chaincode-mount
-          hostPath:
-            path: /mnt/hyperledger/uc4
         - name: scripts
           hostPath:
             path: /mnt/hyperledger/scripts
+        - name: chaincode-mount
+          hostPath:
+            path: /mnt/hyperledger/uc4
+        - name: pod-data
+          emptyDir: {}
         - name: docker-mount
           hostPath:
             path: /var/run/
-        - name: pod-data
-          emptyDir: {}
         - name: tls-ca-cert
           secret:
             secretName: cert.tls-ca

--- a/k8s/org2/peer1-org2.yaml
+++ b/k8s/org2/peer1-org2.yaml
@@ -25,6 +25,10 @@ spec:
           env:
             - name: CORE_PEER_ID
               value: "peer1-org2"
+            - name: CORE_PEER_LISTENADDRESS
+              value: "0.0.0.0:7051"
+            - name: CORE_PEER_ADDRESS
+              value: "peer1-org2:7051"
             - name: CORE_PEER_LOCALMSPID
               value: "org2MSP"
             - name: CORE_PEER_MSPCONFIGPATH
@@ -47,8 +51,14 @@ spec:
               value: "false"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
               value: "peer1-org2:7051"
+            - name: CORE_PEER_BOOTSTRAP
+              value: "peer1-org2:7051"
             - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
               value: "true"
+            - name: CORE_PEER_CHAINCODEADDRESS
+              value: "peer1-org2:7052"
+            - name: CORE_PEER_CHAINCODELISTENADDRESS
+              value: "0.0.0.0:7052"
             - name: CORE_LEDGER_STATE_STATEDATABASE
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
@@ -73,6 +83,8 @@ spec:
           volumeMounts:
             - mountPath: /tmp/hyperledger/scripts
               name: scripts
+            - mountPath: /tmp/hyperledger/shared
+              name: shared-volume
             - mountPath: /tmp/hyperledger/org2/peer1
               name: peer1-org2-mount
             - mountPath: /tmp/secrets/tls-ca
@@ -81,8 +93,6 @@ spec:
             - mountPath: /tmp/secrets/rca-org2
               name: rca-org2-cert
               readOnly: true
-            - mountPath: /tmp/hyperledger/shared
-              name: shared-volume
           env:
             - name: FABRIC_CA_SERVER_DEBUG
               value: "true"
@@ -112,6 +122,7 @@ spec:
                 secretKeyRef:
                   name: credentials.peer1-org2
                   key: password
+            
       volumes:
         - name: peer-persistent-mount
           persistentVolumeClaim:
@@ -122,12 +133,12 @@ spec:
         - name: dind-persistent-mount
           persistentVolumeClaim:
               claimName: peer1-org2-dind-pvc
-        - name: shared-volume
-          hostPath:
-            path: /mnt/hyperledger/shared
         - name: scripts
           hostPath:
             path: /mnt/hyperledger/scripts
+        - name: shared-volume
+          hostPath:
+            path: /mnt/hyperledger/shared
         - name: peer1-org2-mount
           emptyDir: {}
         - name: tls-ca-cert
@@ -153,6 +164,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30211
-    - name: chaincode                                                            
-      protocol: TCP                                                                 
+    - name: chaincode
+      protocol: TCP
       port: 7052

--- a/k8s/org2/peer2-org2-storage.yaml
+++ b/k8s/org2/peer2-org2-storage.yaml
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 5Gi
-      
+
 
 ---
 

--- a/k8s/org2/peer2-org2.yaml
+++ b/k8s/org2/peer2-org2.yaml
@@ -25,6 +25,10 @@ spec:
           env:
             - name: CORE_PEER_ID
               value: "peer2-org2"
+            - name: CORE_PEER_LISTENADDRESS
+              value: "0.0.0.0:7051"
+            - name: CORE_PEER_ADDRESS
+              value: "peer2-org2:7051"
             - name: CORE_PEER_LOCALMSPID
               value: "org2MSP"
             - name: CORE_PEER_MSPCONFIGPATH
@@ -47,10 +51,14 @@ spec:
               value: "false"
             - name: CORE_PEER_GOSSIP_EXTERNALENDPOINT
               value: "peer2-org2:7051"
+            - name: CORE_PEER_BOOTSTRAP
+              value: "peer2-org2:7051"
             - name: CORE_PEER_GOSSIP_SKIPHANDSHAKE
               value: "true"
-            - name: CORE_PEER_GOSSIP_BOOTSTRAP
-              value: "peer1-org2:7051"
+            - name: CORE_PEER_CHAINCODEADDRESS
+              value: "peer2-org2:7052"
+            - name: CORE_PEER_CHAINCODELISTENADDRESS
+              value: "0.0.0.0:7052"
             - name: CORE_LEDGER_STATE_STATEDATABASE
               value: "CouchDB"
             - name: CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS
@@ -73,10 +81,10 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["bash", "./tmp/hyperledger/scripts/startNetwork/enrollJobs/enrollPeer.sh"]
           volumeMounts:
-            - mountPath: /tmp/hyperledger/shared
-              name: shared-volume
             - mountPath: /tmp/hyperledger/scripts
               name: scripts
+            - mountPath: /tmp/hyperledger/shared
+              name: shared-volume
             - mountPath: /tmp/hyperledger/org2/peer2
               name: peer2-org2-mount
             - mountPath: /tmp/secrets/tls-ca
@@ -114,6 +122,7 @@ spec:
                 secretKeyRef:
                   name: credentials.peer2-org2
                   key: password
+
       volumes:
         - name: peer-persistent-mount
           persistentVolumeClaim:
@@ -123,13 +132,13 @@ spec:
               claimName: peer2-org2-couchdb-pvc
         - name: dind-persistent-mount
           persistentVolumeClaim:
-              claimName: peer2-org2-dind-pvc
-        - name: shared-volume
-          hostPath:
-            path: /mnt/hyperledger/shared
+            claimName: peer2-org2-dind-pvc
         - name: scripts
           hostPath:
             path: /mnt/hyperledger/scripts
+        - name: shared-volume
+          hostPath:
+            path: /mnt/hyperledger/shared
         - name: peer2-org2-mount
           emptyDir: {}
         - name: tls-ca-cert
@@ -155,6 +164,6 @@ spec:
       protocol: TCP
       port: 7051
       nodePort: 30221
-    - name: chaincode                                                            
-      protocol: TCP                                                                 
-      port: 7052
+    - name: chaincode                                                           
+      protocol: TCP                                                             
+      port: 7052    


### PR DESCRIPTION
## Reason for this PR:
 
 - Restart failed for `peer2-org2` because wrong `pv` was claimed

## Changes for this  PR:

 - Fix error in `peer2-org2` configuration file that caused wrong `pvc` to `pv` matchings when restarting
 - Refactor `org2` config files to match `org1`s